### PR TITLE
Add cookiecutter option to use `govuk-tech-docs-sphinx-theme`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,16 +19,22 @@ repos:
         types: [ cython, pyi, python ]
         args: [ "--profile", "black", "--filter-files" ]
   - repo: https://github.com/psf/black
-    rev: 21.5b2 # Replace by any tag/version: https://github.com/psf/black/tags
+    rev: 21.5b2
     hooks:
       - id: black
         name: black - consistent Python code formatting (auto-fixes)
-        language_version: python # Should be a command that runs python3.6+
+        language_version: python  # should be a command that runs python3.6+
+        # TODO: Remove exclusion if https://github.com/psf/black/issues/1524 is resolved
+        # The formatting of this file will be checked by the tests in any case
+        exclude: ^\{\{ cookiecutter\.repo_name \}\}/docs/conf\.py$
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8
         name: flake8 - Python linting
+        # Jinja templating in this file raises errors incorrectly; flake8 is checked in
+        # the tests in any case
+        exclude: ^\{\{ cookiecutter\.repo_name \}\}/docs/conf\.py$
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.0.3
     hooks:

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,4 +1,7 @@
 {
+  "_copy_without_render": [
+    "docs/_templates/*"
+  ],
   "_extensions": ["jinja2_time.TimeExtension"],
 
   "organisation_name": "Your public sector organisation name, for example Government Digital Service",
@@ -12,5 +15,8 @@
   "overview": "Brief overview of your project.",
   "project_version": "0.0.1",
 
-  "using_R": ["No", "Yes"]
+  "using_R": ["No", "Yes"],
+  "use_govuk_tech_docs_sphinx_theme": ["Yes", "No"],
+  "documentation_website_domain": "{{ 'Your documentation website domain, e.g. ukgovdatascience.github.io/govcookiecutter' if cookiecutter.use_govuk_tech_docs_sphinx_theme == 'Yes' else 'Not required - press the return key to continue.'}}"
+
 }

--- a/tests/test_govcookiecutter_injected_variables.py
+++ b/tests/test_govcookiecutter_injected_variables.py
@@ -6,7 +6,11 @@ import pytest
 
 # Define the expected counts for each cookiecutter variable - any counts that deviate
 # because of other variables are listed at the end of each dictionary
-ORGANISATION_NAME_COUNT = {
+ORGANISATION_NAME_USE_GOVUK_TECH_DOCS_SPHINX_THEME_YES_COUNT = {
+    "{{ cookiecutter.organisation_name }}.": 3,
+    "({{ cookiecutter.organisation_name }})": 1,
+}
+ORGANISATION_NAME_USE_GOVUK_TECH_DOCS_SPHINX_THEME_NO_COUNT = {
     "{{ cookiecutter.organisation_name }}.": 1,
     "({{ cookiecutter.organisation_name }})": 1,
 }
@@ -17,7 +21,12 @@ ORGANISATION_HANDLE_COUNT = {
     '[u"{{ cookiecutter.organisation_handle }}"],': 0,
     '"{{ cookiecutter.organisation_handle }}",': 0,
 }
-CONTACT_EMAIL_COUNT = {
+CONTACT_EMAIL_USE_GOVUK_TECH_DOCS_SPHINX_THEME_YES_COUNT = {
+    "mailto:{{ cookiecutter.contact_email }}": 3,
+    "[{{ cookiecutter.contact_email }}][email-address].": 1,
+    '"{{ cookiecutter.contact_email }}")': 0,
+}
+CONTACT_EMAIL_USE_GOVUK_TECH_DOCS_SPHINX_THEME_NO_COUNT = {
     "mailto:{{ cookiecutter.contact_email }}": 2,
     "[{{ cookiecutter.contact_email }}][email-address].": 1,
     '"{{ cookiecutter.contact_email }}")': 0,
@@ -37,7 +46,11 @@ REPO_NAME_COUNT = {
     "{{ cookiecutter.repo_name }}": 0,
 }
 OVERVIEW_COUNT = {'"{{ cookiecutter.overview }}",': 0, "{{ cookiecutter.overview }}": 1}
-PROJECT_VERSION_COUNT = {
+PROJECT_VERSION_USE_GOVUK_TECH_DOCS_SPHINX_THEME_YES_COUNT = {
+    '"{{ cookiecutter.project_version }}"': 0,
+    "{{ cookiecutter.project_version }}": 0,
+}
+PROJECT_VERSION_USE_GOVUK_TECH_DOCS_SPHINX_THEME_NO_COUNT = {
     '"{{ cookiecutter.project_version }}"': 2,
     "{{ cookiecutter.project_version }}": 0,
 }
@@ -54,6 +67,14 @@ USING_R_YES_COUNT = {
     "`.Rprofile`": 1,
     "`DESCRIPTION`": 2,
     "`startup.R`": 1,
+}
+DOCUMENTATION_WEBSITE_USE_GOVUK_TECH_DOCS_SPHINX_THEME_YES_COUNT = {
+    "[{{ cookiecutter.documentation_website_domain }}][website]": 1,
+    "https://{{ cookiecutter.documentation_website_domain }}": 1,
+}
+DOCUMENTATION_WEBSITE_USE_GOVUK_TECH_DOCS_SPHINX_THEME_NO_COUNT = {
+    "[{{ cookiecutter.documentation_website_domain }}][website]": 0,
+    "https://{{ cookiecutter.documentation_website_domain }}": 0,
 }
 
 
@@ -135,8 +156,30 @@ def recursive_open_and_count_search_terms(
 
 # Define the test cases for the `test_injected_counts_correct` test
 args_injected_counts_correct = [
-    ("organisation_name", "org_1", ORGANISATION_NAME_COUNT, {"using_R": "No"}),
-    ("organisation_name", "org_2", ORGANISATION_NAME_COUNT, {"using_R": "Yes"}),
+    (
+        "organisation_name",
+        "org_1",
+        ORGANISATION_NAME_USE_GOVUK_TECH_DOCS_SPHINX_THEME_NO_COUNT,
+        {"using_R": "No", "use_govuk_tech_docs_sphinx_theme": "No"},
+    ),
+    (
+        "organisation_name",
+        "org_2",
+        ORGANISATION_NAME_USE_GOVUK_TECH_DOCS_SPHINX_THEME_NO_COUNT,
+        {"using_R": "Yes", "use_govuk_tech_docs_sphinx_theme": "No"},
+    ),
+    (
+        "organisation_name",
+        "org_1",
+        ORGANISATION_NAME_USE_GOVUK_TECH_DOCS_SPHINX_THEME_YES_COUNT,
+        {"using_R": "No", "use_govuk_tech_docs_sphinx_theme": "Yes"},
+    ),
+    (
+        "organisation_name",
+        "org_2",
+        ORGANISATION_NAME_USE_GOVUK_TECH_DOCS_SPHINX_THEME_YES_COUNT,
+        {"using_R": "Yes", "use_govuk_tech_docs_sphinx_theme": "Yes"},
+    ),
     ("organisation_handle", "handle_1", ORGANISATION_HANDLE_COUNT, {"using_R": "No"}),
     (
         "organisation_handle",
@@ -144,12 +187,35 @@ args_injected_counts_correct = [
         {**ORGANISATION_HANDLE_COUNT, '"{{ cookiecutter.organisation_handle }}",': 1},
         {"using_R": "Yes"},
     ),
-    ("contact_email", "email@1", CONTACT_EMAIL_COUNT, {"using_R": "No"}),
+    (
+        "contact_email",
+        "email@1",
+        CONTACT_EMAIL_USE_GOVUK_TECH_DOCS_SPHINX_THEME_NO_COUNT,
+        {"using_R": "No", "use_govuk_tech_docs_sphinx_theme": "No"},
+    ),
     (
         "contact_email",
         "email@2",
-        {**CONTACT_EMAIL_COUNT, '"{{ cookiecutter.contact_email }}")': 1},
-        {"using_R": "Yes"},
+        {
+            **CONTACT_EMAIL_USE_GOVUK_TECH_DOCS_SPHINX_THEME_NO_COUNT,
+            '"{{ cookiecutter.contact_email }}")': 1,
+        },
+        {"using_R": "Yes", "use_govuk_tech_docs_sphinx_theme": "No"},
+    ),
+    (
+        "contact_email",
+        "email@1",
+        CONTACT_EMAIL_USE_GOVUK_TECH_DOCS_SPHINX_THEME_YES_COUNT,
+        {"using_R": "No", "use_govuk_tech_docs_sphinx_theme": "Yes"},
+    ),
+    (
+        "contact_email",
+        "email@2",
+        {
+            **CONTACT_EMAIL_USE_GOVUK_TECH_DOCS_SPHINX_THEME_YES_COUNT,
+            '"{{ cookiecutter.contact_email }}")': 1,
+        },
+        {"using_R": "Yes", "use_govuk_tech_docs_sphinx_theme": "Yes"},
     ),
     ("project_name", "Project_1", PROJECT_NAME_COUNT, {"using_R": "No"}),
     (
@@ -172,15 +238,62 @@ args_injected_counts_correct = [
         {**OVERVIEW_COUNT, "{{ cookiecutter.overview }}": 2},
         {"using_R": "Yes"},
     ),
-    ("project_version", "project_version_1", PROJECT_VERSION_COUNT, {"using_R": "No"}),
+    (
+        "project_version",
+        "project_version_1",
+        PROJECT_VERSION_USE_GOVUK_TECH_DOCS_SPHINX_THEME_NO_COUNT,
+        {"using_R": "No", "use_govuk_tech_docs_sphinx_theme": "No"},
+    ),
     (
         "project_version",
         "project_version_2",
-        {**PROJECT_VERSION_COUNT, "{{ cookiecutter.project_version }}": 1},
-        {"using_R": "Yes"},
+        {
+            **PROJECT_VERSION_USE_GOVUK_TECH_DOCS_SPHINX_THEME_NO_COUNT,
+            "{{ cookiecutter.project_version }}": 1,
+        },
+        {"using_R": "Yes", "use_govuk_tech_docs_sphinx_theme": "No"},
+    ),
+    (
+        "project_version",
+        "project_version_1",
+        PROJECT_VERSION_USE_GOVUK_TECH_DOCS_SPHINX_THEME_YES_COUNT,
+        {"using_R": "No", "use_govuk_tech_docs_sphinx_theme": "Yes"},
+    ),
+    (
+        "project_version",
+        "project_version_2",
+        {
+            **PROJECT_VERSION_USE_GOVUK_TECH_DOCS_SPHINX_THEME_YES_COUNT,
+            "{{ cookiecutter.project_version }}": 1,
+        },
+        {"using_R": "Yes", "use_govuk_tech_docs_sphinx_theme": "Yes"},
     ),
     ("using_R", "No", USING_R_NO_COUNT, {}),
     ("using_R", "Yes", USING_R_YES_COUNT, {}),
+    (
+        "documentation_website_domain",
+        "domain_1",
+        DOCUMENTATION_WEBSITE_USE_GOVUK_TECH_DOCS_SPHINX_THEME_NO_COUNT,
+        {"using_R": "No", "use_govuk_tech_docs_sphinx_theme": "No"},
+    ),
+    (
+        "documentation_website_domain",
+        "domain_2",
+        DOCUMENTATION_WEBSITE_USE_GOVUK_TECH_DOCS_SPHINX_THEME_NO_COUNT,
+        {"using_R": "Yes", "use_govuk_tech_docs_sphinx_theme": "No"},
+    ),
+    (
+        "documentation_website_domain",
+        "domain_1",
+        DOCUMENTATION_WEBSITE_USE_GOVUK_TECH_DOCS_SPHINX_THEME_YES_COUNT,
+        {"using_R": "No", "use_govuk_tech_docs_sphinx_theme": "Yes"},
+    ),
+    (
+        "documentation_website_domain",
+        "domain_2",
+        DOCUMENTATION_WEBSITE_USE_GOVUK_TECH_DOCS_SPHINX_THEME_YES_COUNT,
+        {"using_R": "Yes", "use_govuk_tech_docs_sphinx_theme": "Yes"},
+    ),
 ]
 
 

--- a/{{ cookiecutter.repo_name }}/.govcookiecutter/manifest.json
+++ b/{{ cookiecutter.repo_name }}/.govcookiecutter/manifest.json
@@ -5,6 +5,12 @@
       "description": "R files that are removed if not enabled.",
       "remove": {% if cookiecutter.using_R == "No" %}true{% else %}false{% endif %},
       "resources": [".Rprofile", ".lintr", "DESCRIPTION", "startup.R"]
+    },
+    {
+      "name": "govuk-tech-docs-sphinx-theme usage",
+      "description": "Folders and files removed if not using the theme.",
+      "remove": {% if cookiecutter.use_govuk_tech_docs_sphinx_theme == "No" %}true{% else %}false{% endif %},
+      "resources": ["docs/_templates", "docs/accessibility.md"]
     }
   ]
 }

--- a/{{ cookiecutter.repo_name }}/docs/_templates/autosummary/base.rst
+++ b/{{ cookiecutter.repo_name }}/docs/_templates/autosummary/base.rst
@@ -1,0 +1,6 @@
+``{{ fullname }}``
+{{ ((fullname | length) + 4) * '=' }}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}

--- a/{{ cookiecutter.repo_name }}/docs/_templates/autosummary/class.rst
+++ b/{{ cookiecutter.repo_name }}/docs/_templates/autosummary/class.rst
@@ -1,0 +1,30 @@
+``{{ fullname }}``
+{{ ((fullname | length) + 4) * '=' }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   .. automethod:: __init__
+
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+   {% for item in methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/{{ cookiecutter.repo_name }}/docs/_templates/autosummary/module.rst
+++ b/{{ cookiecutter.repo_name }}/docs/_templates/autosummary/module.rst
@@ -1,0 +1,61 @@
+``{{ fullname | escape }}``
+{{ ((fullname | length) + 4) * '=' }}
+
+.. automodule:: {{ fullname }}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Module Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+{% block modules %}
+{% if modules %}
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+{% for item in modules %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}

--- a/{{ cookiecutter.repo_name }}/docs/accessibility.md
+++ b/{{ cookiecutter.repo_name }}/docs/accessibility.md
@@ -1,0 +1,125 @@
+---
+orphan: true
+---
+# Accessibility statement
+
+This accessibility statement applies to content published on the
+[{{ cookiecutter.documentation_website_domain }}][website] domain.
+
+This website is run by the {{ cookiecutter.organisation_name }}. We want as many people
+as possible to be able to use this website. For example, that means you should be able
+to:
+
+- change colours, contrast levels and fonts
+- zoom in up to 300% without the text spilling off the screen
+- navigate most of the website using just a keyboard
+- navigate most of the website using speech recognition software
+- listen to most of the website using a screen reader (including the most recent
+  versions of JAWS, NVDA and VoiceOver)
+- We've also made the website text as simple as possible to understand.
+
+[AbilityNet][abilitynet] has advice on making your device easier to use if you have a
+disability.
+
+## How accessible this website is
+
+We know some parts of this website are not fully accessible:
+
+- some pages use layout tables rather than CSS tables.
+- some links do not clearly explain where they lead, or that they lead to external
+  sites.
+- there are some external links to websites that may not be accessible.
+
+## Feedback and contact information
+
+If you need information on this website in a different format like accessible PDF,
+large print, easy read, audio recording or braille:
+
+- email [{{ cookiecutter.contact_email }}][email]
+- raise an issue on the [`{{ cookiecutter.repo_name }}` {{ cookiecutter.repository_hosting_platform }} repository][issues]
+
+## Reporting accessibility problems with this website
+
+We're always looking to improve the accessibility of this website. If you find any
+problems not listed on this page or think we're not meeting accessibility requirements,
+[contact us by email][email], or [raise an issue on our {{ cookiecutter.repository_hosting_platform }}
+repository][issues].
+
+## Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public
+Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018
+(the 'accessibility regulations'). If you're not happy with how we respond to your
+complaint, [contact the Equality Advisory and Support Service (EASS)][eass].
+
+## Technical information about this website's accessibility
+
+The {{ cookiecutter.organisation_name }} is committed to making its website accessible,
+in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2)
+Accessibility Regulations 2018.
+
+## Compliance status
+
+This website is partially compliant with the [Web Content Accessibility Guidelines
+version 2.1][wcag] AA standard, due to the non-compliances listed below.
+
+### Non-accessible content
+
+The content listed below is non-accessible for the following reasons.
+
+#### Non-compliance with the accessibility regulations
+
+- Some pages use layout tables rather than CSS tables. This fails [WCAG 2.1 success
+  criteria 1.3.1 Info and Relationships][wcag-2.1-1.3.1] and [1.3.2 Meaningful
+  Sequence][wcag-2.1-1.3.2].
+- Some links do not clearly explain where they lead, or that they lead to external
+  sites. This fails [WCAG 2.1 success criteria 2.4.4 Link Purpose (In
+  Context)][wcag-2.1-2.4.4].
+
+#### Disproportionate burden
+
+[The use of layout tables are due to the use of the
+`sphinx.ext.autosummary`][sphinx-autosummary], and [`sphinx.ext.autodoc`
+extensions][sphinx-autodoc]. This is a third-party, open source code base, and so is
+beyond the scope of this project to fix, although we will apply updates as this
+codebase develops.
+
+#### Content that's not within the scope of the accessibility regulations
+
+The [Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility
+Regulations 2018 legislation][accessibility-legislation] does not require us to fix
+external, third-party websites that are neither funded nor developed by, nor under the
+control of the {{ cookiecutter.organisation_name }}.
+
+## How we tested this website
+
+The test was carried out by the data science team at the Government Digital Service
+(GDS). They used the [WAVE Web Accessibility Evaluation Tool][wave] and a checklist
+created by the GDS technical writing team with help from the GDS accessibility team.
+They tested all pages on this site.
+
+## What we're doing to improve accessibility
+
+We plan to fix the accessibility issues in the content by the end of December {% now "Europe/London", "%Y" %}.
+
+## Preparation of this accessibility statement
+
+This statement was prepared on 21 June 2021. It was last reviewed on 14 July 2021.
+
+[abilitynet]: https://mcmw.abilitynet.org.uk/
+[accessibility-legislation]: https://www.legislation.gov.uk/uksi/2018/952/regulation/4/made
+[eass]: https://www.equalityadvisoryservice.com/
+[email]: mailto:{{ cookiecutter.contact_email }}
+{% if cookiecutter.repository_hosting_platform == "GitHub" -%}
+[issues]: https://github.com/{{ cookiecutter.organisation_handle }}/{{ cookiecutter.repo_name }}/issues/new
+{% elif cookiecutter.repository_hosting_platform == "GitLab" -%}
+[issues]: https://gitlab.com/{{ cookiecutter.organisation_handle }}/{{ cookiecutter.repo_name }}/~/issues/new
+{% endif -%}
+[sphinx-autodoc]: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
+[sphinx-autosummary]: https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html
+[wave]: https://wave.webaim.org/
+[wcag]: https://www.w3.org/TR/WCAG21/
+[wcag-2.1-1.3.1]: https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html
+[wcag-2.1-1.3.2]: https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-sequence.html
+[wcag-2.1-2.4.4]: https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html
+[website]: https://{{ cookiecutter.documentation_website_domain }}

--- a/{{ cookiecutter.repo_name }}/docs/conf.py
+++ b/{{ cookiecutter.repo_name }}/docs/conf.py
@@ -94,7 +94,7 @@ html_theme = "alabaster"
 # For a list of options available for each theme, see the documentation.
 {% if cookiecutter.use_govuk_tech_docs_sphinx_theme == "Yes" -%}
 html_theme_options = {
-    "organisation": "{{ cookiecutter.organisation_name }}",
+    "organisation": "{{ cookiecutter.organisation_name }}",  # noqa: E501
     "phase": "Discovery",
 }
 {% else -%}

--- a/{{ cookiecutter.repo_name }}/docs/conf.py
+++ b/{{ cookiecutter.repo_name }}/docs/conf.py
@@ -13,6 +13,9 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
 import os
+{% if cookiecutter.use_govuk_tech_docs_sphinx_theme == "Yes" -%}
+import subprocess
+{% endif -%}
 import sys
 
 sys.path.insert(0, os.path.abspath(".."))
@@ -30,6 +33,10 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
     "myst_parser",
+{%- if cookiecutter.use_govuk_tech_docs_sphinx_theme == "Yes" %}
+    # "sphinx.ext.githubpages",  -- uncomment if you want to publish to GitHub Pages
+    "govuk_tech_docs_sphinx_theme",
+{%- endif %}
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -49,6 +56,7 @@ master_doc = "index"
 project = "{{ cookiecutter.project_name }}"
 author = "{{ cookiecutter.organisation_handle }}"
 
+{% if cookiecutter.use_govuk_tech_docs_sphinx_theme == "No" -%}
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the built
 # documents.
@@ -56,6 +64,7 @@ author = "{{ cookiecutter.organisation_handle }}"
 version = "{{ cookiecutter.project_version }}"
 # The full version, including alpha/beta/rc tags.
 release = "{{ cookiecutter.project_version }}"
+{% endif -%}
 
 # List of patterns, relative to source directory, that match files and directories to
 # ignore when looking for source files. These patterns also affect html_static_path and
@@ -66,11 +75,31 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "README.md"]
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for a list of
 # builtin themes.
+{% if cookiecutter.use_govuk_tech_docs_sphinx_theme == "Yes" -%}
+html_theme = "govuk_tech_docs_sphinx_theme"
+
+# Variables to pass to each HTML page to help populate page-specific options
+html_context = {
+    "github_url": "https://www.github.com/ukgovdatascience/govcookiecutter",
+    "gitlab_url": None,
+    "conf_py_path": "docs/",
+    "version": "main",
+    "accessibility": "accessibility.md",
+}
+{% else %}
 html_theme = "alabaster"
+{% endif -%}
 
 # Theme options are theme-specific and customize the look and feel of a theme further.
 # For a list of options available for each theme, see the documentation.
+{% if cookiecutter.use_govuk_tech_docs_sphinx_theme == "Yes" -%}
+html_theme_options = {
+    "organisation": "{{ cookiecutter.organisation_name }}",
+    "phase": "Discovery",
+}
+{% else -%}
 # html_theme_options = {}
+{% endif -%}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
@@ -154,6 +183,24 @@ html_static_path = ["_static"]
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = "{{ cookiecutter.repo_name }}doc"
+
+{% if cookiecutter.use_govuk_tech_docs_sphinx_theme == "Yes" -%}
+# -- Options for govuk-tech-docs-sphinx-theme ------------------------------------------
+
+# Get the latest Git commit hash — this is used to redirect the 'View Source' link
+# correctly. If this fails, default to `main`. Based on code snippet from:
+# https://github.com/sphinx-doc/sphinx/blob/1ebc9c26c7a4c484733beb9f8e39e93846d86494/sphinx/__init__.py#L53  # noqa: E501
+try:
+    p = subprocess.run(
+        ["git", "show", "-s", "--pretty=format:%H"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding="ascii",
+    )
+    git_version = p.stdout if p.stdout else "main"
+except Exception:
+    git_version = "main"
+{% endif -%}
 
 # -- Options for autosection output ----------------------------------------------------
 

--- a/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/{{ cookiecutter.repo_name }}/requirements.txt
@@ -1,5 +1,8 @@
 coverage
 detect-secrets==1.0.3
+{% if cookiecutter.use_govuk_tech_docs_sphinx_theme == "Yes" -%}
+govuk-tech-docs-sphinx-theme
+{% endif -%}
 myst-parser
 pre-commit
 pytest


### PR DESCRIPTION
# Summary

This pull request provides users an option to create a new project from `govcookiecutter` with the GOV.UK Tech Docs Sphinx theme automatically applied.

This includes a standard accessibility statement, based on accessibility checks of the content already completed in PR #33 and PR #37.

# Checklists

<!--
These are DO-CONFIRM checklists; it CONFIRMs that you have DOne each item.

Outstanding actions should be completed before reviewers are assigned; if actions are
irrelevant, please try and add a comment stating why.

Incomplete pull/merge requests MAY be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull/merge request meets the following requirements:

- [x] code runs
- [x] [developments are ethical][data-ethics-framework] and secure
- [x] you have made proportionate checks that the code works correctly
- [x] you have tested the build of the template
- [x] test suite passes
- [x] [minimum usable documentation][agilemodeling] written in the `docs` folder

Comments have been added below around the incomplete checks.

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
