### PR TITLE
docs: change negative contractions link

### DIFF
--- a/{{ cookiecutter.repo_name }}/docs/contributor_guide/writing_accessible_documentation.md
+++ b/{{ cookiecutter.repo_name }}/docs/contributor_guide/writing_accessible_documentation.md
@@ -48,5 +48,5 @@ GOV.UK][govuk-sample-accessibility].
 [govuk-design-system-images]: https://design-system.service.gov.uk/styles/images/
 [govuk-language]: https://www.gov.uk/government/publications/inclusive-communication/inclusive-language-words-to-use-and-avoid-when-writing-about-disability
 [govuk-sample-accessibility]: https://www.gov.uk/government/publications/sample-accessibility-statement
-[negative-contractions]: https://www.englishclub.com/vocabulary/contractions-negative.htm
+[negative-contractions]: https://www.thoughtco.com/what-is-a-negative-contraction-1691339#:~:text=A%20negative%20contraction%20is%20a,won't%2C%20wouldn't
 [wave]: https://wave.webaim.org/


### PR DESCRIPTION
The negative contractions link in the documents keeps throwing an error with the link checker workflow. 

Add your summary here - keep it brief, to the point, and in plain English. [For further
information about pull requests, check out the GDS
Way](https://gds-way.cloudapps.digital/standards/pull-requests.html).

# Checklists

<!--
These are DO-CONFIRM checklists; it CONFIRMs that you have DOne each item.

Outstanding actions should be completed before reviewers are assigned; if actions are
irrelevant, please try and add a comment stating why.

Incomplete pull/merge requests MAY be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull/merge request meets the following requirements:

- [ ] code runs
- [ ] [developments are ethical][data-ethics-framework] and secure
- [ ] you have made proportionate checks that the code works correctly
- [ ] you have tested the build of the template
- [ ] test suite passes
- [ ] [minimum usable documentation][agilemodeling] written in the `docs` folder

Comments have been added below around the incomplete checks.

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
