### PR TITLE
docs: update docs in contributing guide for running pytests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,12 +65,11 @@ enforced in all cases, for example with long hyperlinks.
 ## Testing
 
 [Tests are written using the `pytest` framework][pytest], with its configuration in the
-`pyproject.toml` file. Note, only tests in the `tests`, and
-`{{ cookiecutter.repo_name }}/tests` folders folder are run. To run the tests, enter
+`pyproject.toml` file. Note, only the `tests` folder in the root direcrtory of this project are to run. To run the tests, enter
 the following command in your terminal:
 
 ```shell
-pytest
+pytest tests
 ```
 
 ### Code coverage


### PR DESCRIPTION
# Summary

The contributing guide current suggests running pytests within the end user package. This branch changes that to just the tests folder in the root directory. This is because the tests within the end user package are example pytests for the user.

# Checklists

<!--
These are DO-CONFIRM checklists; it CONFIRMs that you have DOne each item.

Outstanding actions should be completed before reviewers are assigned; if actions are
irrelevant, please try and add a comment stating why.

Incomplete pull/merge requests MAY be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull/merge request meets the following requirements:

- [ ] code runs
- [ ] [developments are ethical][data-ethics-framework] and secure
- [ ] you have made proportionate checks that the code works correctly
- [ ] you have tested the build of the template
- [ ] test suite passes
- [ ] [minimum usable documentation][agilemodeling] written in the `docs` folder

Comments have been added below around the incomplete checks.

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
