### PR TITLE
update reqs for pytestcookies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@ bandit
 cookiecutter
 coverage
 detect-secrets==1.0.3
-#pytest-cookies
-git+https://github.com/Jacobb164/pytest-cookies
+pytest-cookies
 govuk-tech-docs-sphinx-theme
 jinja2-time
 myst-parser


### PR DESCRIPTION
# Summary
The pytest-cookies previously being used as a requirement was a forked copy to address a bug which looks to have since been fixed on pytest-cookies itself, so reverting back to the original.

# Checklists
This pull/merge request meets the following requirements:

- [x] code runs
- [x] [developments are ethical][data-ethics-framework] and secure
- [x] you have made proportionate checks that the code works correctly
- [ ] you have tested the build of the template _see below_
- [ ] test suite passes _see below_
- [ ] [minimum usable documentation][agilemodeling] written in the `docs` folder **NA**

Template build - blocked by issues with Sphinx
Tests - the failure/pass rate was the same before and after pytest-cookies is updated.

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
