### PR TITLE
update build workflow python versions

### DIFF
--- a/.github/workflows/govcookiecutter-template-build.yml
+++ b/.github/workflows/govcookiecutter-template-build.yml
@@ -16,12 +16,12 @@ jobs:
       matrix:
         # TODO: Fix R pre-commit hook issues with Windows
         os: [ ubuntu-latest] #, macos-latest ]
-        python: [3.9, '3.10']
+        python: [3.9, '3.10', 3.11, 3.12]
         R:
 #          - {using_R: No, version: N/A}
           - {using_R: Yes, version: 4.2.3}
 #          - {using_R: Yes, version: 4.3.3}
-#          - {using_R: Yes, version: 4.4.3}
+          - {using_R: Yes, version: 4.4.3}
 
     steps:
       - name: Checkout the revision
@@ -91,7 +91,5 @@ jobs:
         run: |
           cd example
           pre-commit run --all-files
-          git diff --name-only
-          git diff
           # TODO: Currently no tests - this gives exit code 5, which fails CI, so commenting out for now
           # pytest


### PR DESCRIPTION
# Summary
Update python versions in template build workflow. Was breaking due to a dependency not being compatible with 3.8, which is fully deprecated. 

# Checklists

This pull/merge request meets the following requirements:

- [ ] code runs
- [x] [developments are ethical][data-ethics-framework] and secure
- [ ] you have made proportionate checks that the code works correctly
- [ ] you have tested the build of the template
- [ ] test suite passes
- [ ] [minimum usable documentation][agilemodeling] written in the `docs` folder **NA**
- [ ] changelog has been updated **NA** Covered already

Comments have been added below around the incomplete checks.

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
