### PR TITLE
Ruff testing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,0 @@
-[flake8]
-# Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
-# D203: 1 blank line required before class docstring
-# W503: line break before binary operator
-exclude = venv*,__pycache__,node_modules,bower_components,migrations
-ignore = D203,W503
-max-complexity = 9
-max-line-length = 88
-extend-ignore = E203

--- a/.github/workflows/govcookiecutter-build.yml
+++ b/.github/workflows/govcookiecutter-build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run pre-commit hooks
         run: pre-commit run --all-files
       - name: Clear ruff cache
-        run: ruff clear
+        run: ruff clean
       - name: Create documentation
         run: |
           if [[ "$RUNNER_OS" == "Linux" || "$RUNNER_OS" == "macOS" ]]; then

--- a/.github/workflows/govcookiecutter-build.yml
+++ b/.github/workflows/govcookiecutter-build.yml
@@ -29,6 +29,8 @@ jobs:
         shell: bash
       - name: Run pre-commit hooks
         run: pre-commit run --all-files
+      - name: Clear ruff cache
+        run: ruff clear
       - name: Create documentation
         run: |
           if [[ "$RUNNER_OS" == "Linux" || "$RUNNER_OS" == "macOS" ]]; then

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     rev: v0.11.12
     hooks:
       # Run ruff linter.
-      - id: ruff
+      - id: ruff-check
         types_or: [ python, pyi ]
         args: [ --fix ]
       # Run ruff formatter.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,10 @@ repos:
       - id: check-added-large-files
         name: Check for files larger than 5 MB
         args: [ "--maxkb=5120" ]
-      - id: end-of-file-fixer
-        name: Check for a blank line at the end of scripts (auto-fixes)
-      - id: trailing-whitespace
-        name: Check for trailing whitespaces (auto-fixes)
+      # - id: end-of-file-fixer
+      #   name: Check for a blank line at the end of scripts (auto-fixes)
+      # - id: trailing-whitespace
+      #   name: Check for trailing whitespaces (auto-fixes)
   # - repo: https://github.com/pycqa/isort
   #   rev: 6.0.1
   #   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,19 +18,19 @@ repos:
         name: isort - Sort Python imports (auto-fixes)
         args: [ "--profile", "black", "--filter-files" ]
         exclude: test_example_module.py|run_pipeline.py
-  - repo: https://github.com/psf/black
-    rev: 25.1.0 # Replace by any tag/version: https://github.com/psf/black/tags
-    hooks:
-      - id: black
-        name: black - consistent Python code formatting (auto-fixes)
-        language_version: python # Should be a command that runs python3.6+
-        exclude: test_example_module.py|run_pipeline.py
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.2
-    hooks:
-      - id: flake8
-        name: flake8 - Python linting
-        exclude: test_example_module.py|run_pipeline.py
+  # - repo: https://github.com/psf/black
+  #   rev: 25.1.0 # Replace by any tag/version: https://github.com/psf/black/tags
+  #   hooks:
+  #     - id: black
+  #       name: black - consistent Python code formatting (auto-fixes)
+  #       language_version: python # Should be a command that runs python3.6+
+  #       exclude: test_example_module.py|run_pipeline.py
+  # - repo: https://github.com/PyCQA/flake8
+  #   rev: 7.1.2
+  #   hooks:
+  #     - id: flake8
+  #       name: flake8 - Python linting
+  #       exclude: test_example_module.py|run_pipeline.py
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:
@@ -45,3 +45,14 @@ repos:
         name: bandit - Checks for vulnerabilities
         args: ["-c", "pyproject.toml"]
         additional_dependencies: ["bandit[toml]"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.11.12
+    hooks:
+      # Run the linter.
+      - id: ruff
+        types_or: [ python, pyi ]
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format
+        types_or: [ python, pyi ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,13 +11,13 @@ repos:
         name: Check for a blank line at the end of scripts (auto-fixes)
       - id: trailing-whitespace
         name: Check for trailing whitespaces (auto-fixes)
-  - repo: https://github.com/pycqa/isort
-    rev: 6.0.1
-    hooks:
-      - id: isort
-        name: isort - Sort Python imports (auto-fixes)
-        args: [ "--profile", "black", "--filter-files" ]
-        exclude: test_example_module.py|run_pipeline.py
+  # - repo: https://github.com/pycqa/isort
+  #   rev: 6.0.1
+  #   hooks:
+  #     - id: isort
+  #       name: isort - Sort Python imports (auto-fixes)
+  #       args: [ "--profile", "black", "--filter-files" ]
+  #       exclude: test_example_module.py|run_pipeline.py
   # - repo: https://github.com/psf/black
   #   rev: 25.1.0 # Replace by any tag/version: https://github.com/psf/black/tags
   #   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,30 +7,6 @@ repos:
       - id: check-added-large-files
         name: Check for files larger than 5 MB
         args: [ "--maxkb=5120" ]
-      # - id: end-of-file-fixer
-      #   name: Check for a blank line at the end of scripts (auto-fixes)
-      # - id: trailing-whitespace
-      #   name: Check for trailing whitespaces (auto-fixes)
-  # - repo: https://github.com/pycqa/isort
-  #   rev: 6.0.1
-  #   hooks:
-  #     - id: isort
-  #       name: isort - Sort Python imports (auto-fixes)
-  #       args: [ "--profile", "black", "--filter-files" ]
-  #       exclude: test_example_module.py|run_pipeline.py
-  # - repo: https://github.com/psf/black
-  #   rev: 25.1.0 # Replace by any tag/version: https://github.com/psf/black/tags
-  #   hooks:
-  #     - id: black
-  #       name: black - consistent Python code formatting (auto-fixes)
-  #       language_version: python # Should be a command that runs python3.6+
-  #       exclude: test_example_module.py|run_pipeline.py
-  # - repo: https://github.com/PyCQA/flake8
-  #   rev: 7.1.2
-  #   hooks:
-  #     - id: flake8
-  #       name: flake8 - Python linting
-  #       exclude: test_example_module.py|run_pipeline.py
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:
@@ -46,13 +22,12 @@ repos:
         args: ["-c", "pyproject.toml"]
         additional_dependencies: ["bandit[toml]"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
     rev: v0.11.12
     hooks:
-      # Run the linter.
+      # Run ruff linter.
       - id: ruff
         types_or: [ python, pyi ]
         args: [ --fix ]
-      # Run the formatter.
+      # Run ruff formatter.
       - id: ruff-format
         types_or: [ python, pyi ]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # `govcookiecutter`
+[![Deploy Documentation](https://github.com/best-practice-and-impact/govcookiecutter/actions/workflows/govcookiecutter-deploy-documentation.yml/badge.svg)](https://github.com/best-practice-and-impact/govcookiecutter/actions/workflows/govcookiecutter-deploy-documentation.yml)
+[![template build](https://github.com/best-practice-and-impact/govcookiecutter/actions/workflows/govcookiecutter-template-build.yml/badge.svg)](https://github.com/best-practice-and-impact/govcookiecutter/actions/workflows/govcookiecutter-template-build.yml)
+[![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 ## What is govcookiecutter?
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,3 +1,4 @@
+import os
 from json import load
 from pathlib import Path
 from shutil import rmtree
@@ -22,6 +23,16 @@ def delete_files_and_folders(paths: Union[Path, str, List[Path], List[str]]) -> 
     paths = [Path(p) for p in paths] if isinstance(paths, List) else [Path(paths)]
     _ = [rmtree(d) for d in paths if d.is_dir() and d.exists()]
     _ = [f.unlink() for f in paths if f.is_file() and f.exists()]
+
+
+def remove_excluded_ruff_path() -> None:
+    """Remove the excluded files from the ruff config in pyproject.toml."""
+    print("Current working directory:", os.getcwd())
+    pyproject_path = Path("pyproject.toml")
+    if pyproject_path.exists():
+        content = pyproject_path.read_text(encoding="utf-8")
+        new_content = content.replace('["**/*"]', "[]")
+        pyproject_path.write_text(new_content, encoding="utf-8")
 
 
 def set_aqa_framework(
@@ -164,3 +175,5 @@ if __name__ == "__main__":
 
     # Remove `DIR_GOVCOOKIECUTTER`
     delete_files_and_folders(DIR_GOVCOOKIECUTTER)
+
+    remove_excluded_ruff_path()

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -134,13 +134,11 @@ def parse_features_json(file: Union[Path, str]) -> List[Path]:
 
 
 if __name__ == "__main__":
-
     # Define the folder path to `.govcookiecutter`
     DIR_GOVCOOKIECUTTER = Path(".govcookiecutter")
 
     # Check `{{ cookiecutter.organisational_framework }}` is not `N/A`
     if "{{ cookiecutter.organisational_framework }}" != "N/A":
-
         # Define the folder path to the specific organisation framework of interest in
         # the `organisational_frameworks`
         # folder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,11 @@ select = [
     ]
 
 [tool.ruff]
-line-length = 100
+line-length = 88
 exclude = [
     "[{][{] cookiecutter.repo_name.lower().replace(' ', '_').replace('-', '_') [}][}]",
     "[{][{] cookiecutter.repo_name [}][}]/tests/"
 ]
+
+[tool.ruff.format]
+line-ending = "lf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,24 @@ testpaths = [
 [tool.bandit]
 exclude_dirs = ["tests", "docs"]
 skips = []
+
+[tool.ruff.lint]
+select = [
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "B",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+    ]
+
+[tool.ruff]
+line-length = 100
+exclude = [
+    "[{][{] cookiecutter.repo_name.lower().replace(' ', '_').replace('-', '_') [}][}]",
+    "[{][{] cookiecutter.repo_name [}][}]/tests/"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,7 @@ ignore = ["D203", "E203"]
 [tool.ruff]
 line-length = 88
 exclude = [
-    "[{][{] cookiecutter.repo_name.lower().replace(' ', '_').replace('-', '_') [}][}]",
-    "[{][{] cookiecutter.repo_name [}][}]/tests/"
+    "[{][{] cookiecutter.repo_name [}][}]/"
 ]
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,4 +61,4 @@ exclude = [
 ]
 
 [tool.ruff.format]
-line-ending = "lf"
+line-ending = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ select = [
     # isort
     "I",
     ]
+ignore = ["D203", "E203"]
 
 [tool.ruff]
 line-length = 88

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,5 @@ pytest-mock
 pytest-xdist
 python-dotenv
 Sphinx
-# sphinxcontrib-applehelp==1.0.4 #downgraded from 2.0.0
-# sphinxcontrib-devhelp==1.0.2 #downgraded from 2.0.0
-# sphinxcontrib-htmlhelp==2.0.1 #downgraded from 2.1.0
-# sphinxcontrib-serializinghtml==1.1.5 #downgraded from 2.0.0
-# sphinxcontrib-qthelp==1.0.3 #downgraded from 2.0.0
 toml
+ruff

--- a/tests/test_govcookiecutter_creation.py
+++ b/tests/test_govcookiecutter_creation.py
@@ -48,7 +48,7 @@ def test_request_template_generated_correctly(
 
 
 @pytest.mark.skip(
-    reason="Unclear how to test this, unless there is a title in each " "framework"
+    reason="Unclear how to test this, unless there is a title in each framework"
 )
 def test_organisational_framework_correct() -> None:
     """Test that the correct organisational framework is built."""

--- a/tests/test_govcookiecutter_injected_variables.py
+++ b/tests/test_govcookiecutter_injected_variables.py
@@ -199,7 +199,6 @@ def test_injected_counts_correct(
     test_input_variable_counts: Dict[str, int],
     test_input_other_context: Dict[str, str],
 ) -> None:
-
     # Generate the expected counts
     test_expected_counts = replace_cookiecutter_jinja2_counts(
         test_input_variable_counts,

--- a/tests/test_post_gen_project/test_delete_files_and_folders.py
+++ b/tests/test_post_gen_project/test_delete_files_and_folders.py
@@ -45,8 +45,8 @@ args_test_delete_files_and_folders = [
 
 
 @pytest.mark.parametrize(
-    "test_input_folder_names, test_extra_folder_names, test_input_filenames, "
-    "test_extra_filenames",
+    "test_input_folder_names, test_extra_folder_names, "
+    "test_input_filenames, test_extra_filenames",
     args_test_delete_files_and_folders,
 )
 class TestDeleteFilesAndFolders:

--- a/{{ cookiecutter.repo_name }}/.flake8
+++ b/{{ cookiecutter.repo_name }}/.flake8
@@ -1,9 +1,0 @@
-[flake8]
-# Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
-# D203: 1 blank line required before class docstring
-# W503: line break before binary operator
-exclude = venv*,__pycache__,node_modules,bower_components,migrations
-ignore = D203,W503
-max-complexity = 9
-max-line-length = 88
-extend-ignore = E203

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -81,54 +81,17 @@ repos:
       args:
         - "--maxkb=5120"
 
-    - id: end-of-file-fixer
-      name: Check for a blank line at the end of scripts (auto-fixes)
-      entry: end-of-file-fixer
-      language: system
-      exclude: '\.Rd'
+    - id: ruff-check
+      name: ruff check
+      description: "Run 'ruff check' for extremely fast Python linting"
+      entry: ruff check --force-exclude
+      language: python
 
-    - id: trailing-whitespace
-      name: Check for trailing whitespaces (auto-fixes)
-      entry: trailing-whitespace-fixer
-      language: system
-
-    - id: isort
-      name: isort - Sort python imports (auto-fixes)
-      entry: isort
-      language: system
-      args:
-        - "--profile"
-        - "black"
-        - "--filter-files"
-
-    - id: black
-      name: black - consistent Python code formatting (auto-fixes)
-      entry: black
-      language: system
-      types: [python]
-
-    - id: flake8
-      name: flake8 - Python linting
-      entry: flake8
-      language: system
-      types: [python]
-
-    - id: nbqa-isort
-      name: nbqa-isort - Sort Python imports (notebooks; auto-fixes)
-      entry: nbqa
-      language: system
-      args:
-        - isort
-        - --nbqa-mutate
-
-    - id: nbqa-black
-      name: nbqa-black - consistent Python code formatting (notebooks; auto-fixes)
-      entry: nbqa
-      language: system
-      types: [python]
-      args:
-        - black
-        - --nbqa-mutate
+    - id: ruff-format
+      name: ruff format
+      description: "Run 'ruff format' for extremely fast Python formatting"
+      entry: ruff format --force-exclude
+      language: python
 
     - id: detect-secrets
       name: detect-secrets - Detect secrets in staged code

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -85,12 +85,15 @@ repos:
       name: ruff check
       description: "Run 'ruff check' for extremely fast Python linting"
       entry: ruff check --force-exclude
+      types_or: [python, pyi, jupyter]
+      args: [--fix]
       language: python
 
     - id: ruff-format
       name: ruff format
       description: "Run 'ruff format' for extremely fast Python formatting"
       entry: ruff format --force-exclude
+      types_or: [python, pyi, jupyter]
       language: python
 
     - id: detect-secrets

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -16,51 +16,14 @@ repos:
       - id: check-added-large-files
         name: Check for files larger than 5 MB
         args: [ "--maxkb=5120" ]
-      - id: end-of-file-fixer
-        name: Check for a blank line at the end of scripts (auto-fixes)
-        exclude: '\.Rd'
-      - id: trailing-whitespace
-        name: Check for trailing whitespaces (auto-fixes)
-  - repo: https://github.com/pycqa/isort
-    rev: 6.0.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.12
     hooks:
-      - id: isort
-        name: isort - Sort python imports (auto-fixes)
-        args: [ "--profile", "black", "--filter-files" ]
-      - id: isort
-        name: isort - Sort cython imports (auto-fixes)
-        types: [cython]
-        args: [ "--profile", "black", "--filter-files" ]
-      - id: isort
-        name: isort - Sort pyi imports (auto-fixes)
-        types: [pyi]
-        args: [ "--profile", "black", "--filter-files" ]
-  - repo: https://github.com/psf/black
-    rev: 25.1.0 # Replace by any tag/version: https://github.com/psf/black/tags
-    hooks:
-      - id: black
-        name: black - consistent Python code formatting (auto-fixes)
-        language_version: python # Should be a command that runs python3.6+
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.2
-    hooks:
-      - id: flake8
-        name: flake8 - Python linting
-  - repo: https://github.com/nbQA-dev/nbQA
-    rev: 0.12.0
-    hooks:
-      - id: nbqa-isort
-        name: nbqa-isort - Sort Python imports (notebooks; auto-fixes)
-        args: [ --nbqa-mutate ]
-        additional_dependencies: [ isort==5.8.0 ]
-      - id: nbqa-black
-        name: nbqa-black - consistent Python code formatting (notebooks; auto-fixes)
-        args: [ --nbqa-mutate ]
-        additional_dependencies: [ black==21.5b2 ]
-      # TODO: Disabled for now until it's clear how to add noqa to specific cells of a Jupyter notebook
-      #- id: nbqa-flake8
-      #  name: nbqa-flake8 - Python linting (notebooks)
-      #  additional_dependencies: [ flake8==3.9.2 ]
+      # Run ruff linter.
+      - id: ruff-check
+        args: [ --fix ]
+      # Run ruff formatter.
+      - id: ruff-format
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -28,3 +28,28 @@ testpaths = [
 [tool.bandit]
 exclude_dirs = ["tests", "docs"]
 skips = []
+
+[tool.ruff.lint]
+select = [
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "B",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+    ]
+ignore = ["D203", "E203"]
+
+[tool.ruff]
+line-length = 88
+exclude = [
+    "[{][{] cookiecutter.repo_name.lower().replace(' ', '_').replace('-', '_') [}][}]",
+    "[{][{] cookiecutter.repo_name [}][}]/tests/"
+]
+
+[tool.ruff.format]
+line-ending = "lf"

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -46,10 +46,7 @@ ignore = ["D203", "E203"]
 
 [tool.ruff]
 line-length = 88
-exclude = [
-    "[{][{] cookiecutter.repo_name.lower().replace(' ', '_').replace('-', '_') [}][}]",
-    "[{][{] cookiecutter.repo_name [}][}]/tests/"
-]
+
 
 [tool.ruff.format]
 line-ending = "auto"

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -52,4 +52,4 @@ exclude = [
 ]
 
 [tool.ruff.format]
-line-ending = "lf"
+line-ending = "auto"

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -47,8 +47,8 @@ ignore = ["D203", "E203"]
 [tool.ruff]
 line-length = 88
 exclude = [
-    "[{][{] cookiecutter.repo_name.lower().replace(' ', '_').replace('-', '_') [}][}]/",
-    "tests/"
+    "[{][{] cookiecutter.repo_name.lower().replace(' ', '_').replace('-', '_') [}][}]/run_pipeline.py",
+    "tests/test_example_module.py",
 ]
 
 [tool.ruff.format]

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -46,10 +46,7 @@ ignore = ["D203", "E203"]
 
 [tool.ruff]
 line-length = 88
-exclude = [
-    "[{][{] cookiecutter.repo_name.lower().replace(' ', '_').replace('-', '_') [}][}]/run_pipeline.py",
-    "tests/test_example_module.py",
-]
+exclude = ["**/*"]
 
 [tool.ruff.format]
 line-ending = "auto"

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -46,7 +46,10 @@ ignore = ["D203", "E203"]
 
 [tool.ruff]
 line-length = 88
-
+exclude = [
+    "[{][{] cookiecutter.repo_name.lower().replace(' ', '_').replace('-', '_') [}][}]/",
+    "tests/"
+]
 
 [tool.ruff.format]
 line-ending = "auto"

--- a/{{ cookiecutter.repo_name }}/setup.cfg
+++ b/{{ cookiecutter.repo_name }}/setup.cfg
@@ -28,7 +28,7 @@ dev =
     detect-secrets
     python-dotenv
     Sphinx
-    toml {% if cookiecutter.locked_down_environment == "Yes" %}
+    toml{% if cookiecutter.locked_down_environment == "Yes" %}
     pre-commit-hooks
     nbstripout
     isort

--- a/{{ cookiecutter.repo_name }}/setup.cfg
+++ b/{{ cookiecutter.repo_name }}/setup.cfg
@@ -31,8 +31,5 @@ dev =
     toml{% if cookiecutter.locked_down_environment == "Yes" %}
     pre-commit-hooks
     nbstripout
-    isort
-    black
-    flake8
-    nbqa
+    ruff
     bandit {% endif -%}


### PR DESCRIPTION
# Summary

Replacing Flake8 and Black with ruff formater and linter 
updated both locked down and open commit hooks
created new post gen hook to remove fix for having two pyproject.toml files with ruff configurations, set the lower level to ignore everything, this is then removed once new repo is created.


# Checklists

<!--
These are DO-CONFIRM checklists; it CONFIRMs that you have done each item.

Outstanding actions should be completed before reviewers are assigned; if actions are
irrelevant, please try and add a comment stating why.

Incomplete pull/merge requests MAY be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull/merge request meets the following requirements:

- [x] code runs
- [x] [developments are ethical][data-ethics-framework] and secure
- [x] you have made proportionate checks that the code works correctly
- [x] you have tested the build of the template
- [x] test suite passes
- [x] [minimum usable documentation][agilemodeling] written in the `docs` folder
- [ ] changelog has been updated

Comments have been added below around the incomplete checks.

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
